### PR TITLE
Add -lcrypt for Linux.

### DIFF
--- a/src/mconfig.h-linux
+++ b/src/mconfig.h-linux
@@ -62,7 +62,7 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA. */
 #endif
 
 #ifdef WNN4
-#define LIBWNN -lwnn
+#define LIBWNN -lwnn -lcrypt
 #define INCWNN -I/usr/include/wnn
 #endif  /* not WNN4 */
 


### PR DESCRIPTION
This PR adds missing `-lcrypt` in `src/mconfig.h-linux`.
I tested this on Ubuntu 18.04 amd64 machine.