### PR TITLE
Protect objects correctly in call4().

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1693,6 +1693,7 @@ call4 (Lisp_Object fn, Lisp_Object arg, Lisp_Object arg1, Lisp_Object arg2, Lisp
   args[2] = arg1;
   args[3] = arg2;
   args[4] = arg3;
+  gcpro1.var = args;
   val = Ffuncall (5, args);
 #else /* not NO_ARG_ARRAY */
   val = Ffuncall (5, &fn);


### PR DESCRIPTION
When using `require` or `autoload`, this caused memory corruption in garbage collection.

This problem occurred when using SKK 7.18.  
I've got the following backtrace with gdb.

```
#0  0x000000000044aad7 in Fgarbage_collect () at alloc.c:843
#1  0x00000000004582be in Ffuncall (nargs=2, args=0x7ffffffedbf0) at eval.c:1728
#2  0x000000000046890d in Fbyte_code (bytestr=-9007199254733984976, vector=-8935141660696056232, maxdepth=16)
    at bytecode.c:274
#3  0x0000000000457783 in Feval (form=360287970196646688) at eval.c:1431
#4  0x0000000000454e2b in Fprogn (args=360287970196646672) at eval.c:318
#5  0x0000000000458edf in funcall_lambda (fun=360287970196647928, nargs=4, arg_vector=0x7ffffffee0b8) at eval.c:1941
#6  0x00000000004588e9 in Ffuncall (nargs=5, args=0x7ffffffee0b0) at eval.c:1834
#7  0x00000000004581fa in call4 (fn=-9151314442809364848, arg=216172782122113512, arg1=72057594045371408,
    arg2=72057594045371408, arg3=72057594045371408) at eval.c:1696
#8  0x0000000000456e16 in do_autoload (fundef=360287970197445808, funname=72057594046070416) at eval.c:1253
#9  0x000000000042aae4 in Fcommand_execute (cmd=72057594046070416, record=72057594045371408) at keyboard.c:1893
#10 0x000000000042931f in command_loop_1 () at keyboard.c:849
#11 0x0000000000456537 in internal_condition_case (bfun=0x428ad7 <command_loop_1>, handlers=72057594045371888,
    hfun=0x4285d5 <cmd_error>) at eval.c:998
#12 0x0000000000428986 in command_loop_2 () at keyboard.c:600
#13 0x0000000000455f1c in internal_catch (tag=72057594045371848, func=0x428964 <command_loop_2>, arg=72057594045371408)
    at eval.c:810
#14 0x0000000000428947 in command_loop () at keyboard.c:582
#15 0x000000000042854e in recursive_edit_1 () at keyboard.c:474
#16 0x00000000004284d1 in Frecursive_edit () at keyboard.c:457
#17 0x0000000000427e33 in main (argc=1, argv=0x7ffffffee688, envp=0x7ffffffee698) at emacs.c:788
```

I tested this commit on Ubuntu 18.04 amd64 VM.